### PR TITLE
Add responsive mobile layout

### DIFF
--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -23,8 +23,12 @@ export default function Header() {
           <p className="mb-4">
             B4 in Information Science, University of Tsukuba
           </p>
-          <p>Web development / App development / Software engineering</p>
-          <p>Boid model / Artificial Life / Evolutionary computation</p>
+          <p className="hidden md:block">
+            Web development / App development / Software engineering
+          </p>
+          <p className="hidden md:block">
+            Boid model / Artificial Life / Evolutionary computation
+          </p>
         </div>
 
         {/* SNSリンク */}

--- a/src/app/components/History.tsx
+++ b/src/app/components/History.tsx
@@ -105,7 +105,7 @@ export default function History() {
   return (
     <section className="py-16 md:py-20 px-8">
       <div className="w-full max-w-7xl mx-auto">
-        <h2 className="font-vt text-6xl md:text-7xl mb-12 text-center md:text-left">
+        <h2 className="font-vt text-6xl md:text-7xl mb-12 text-center">
           HISTORY
         </h2>
 
@@ -114,7 +114,7 @@ export default function History() {
             <div key={intern.id} className="relative mb-12">
               <div className="flex flex-col md:flex-row items-center gap-6">
                 {/* 左側: タイムライン */}
-                <div className="relative min-w-[250px] flex justify-center">
+                <div className="hidden md:flex relative min-w-[250px] justify-center">
                   <Image
                     src="/timeline/treasure.webp"
                     alt="Timeline Icon"
@@ -125,7 +125,7 @@ export default function History() {
                 </div>
 
                 {/* 右側: カード */}
-                <div className="flex-1 border-4 border-[#E53C93] rounded-lg p-6 md:p-8">
+                <div className="flex-1 border-4 border-[#E53C93] rounded-lg p-6 md:p-8 flex flex-col items-center text-center md:text-left md:items-start">
                   {/* 会社名 */}
                   <h3 className="font-kiwi font-medium text-3xl md:text-4xl mb-3">
                     {intern.company}
@@ -164,7 +164,7 @@ export default function History() {
                   </div>
 
                   {/* 技術スタック */}
-                  <div className="flex flex-wrap gap-4 items-center">
+                  <div className="flex flex-wrap gap-4 items-center justify-center md:justify-start">
                     {intern.techStack.map((tech, index) => (
                       <Image
                         key={index}

--- a/src/app/components/Qualifications.tsx
+++ b/src/app/components/Qualifications.tsx
@@ -44,13 +44,13 @@ export default function Qualifications() {
                   alt=""
                   width={100}
                   height={150}
-                  className="object-contain"
+                  className="object-contain w-10 h-10 md:w-[100px] md:h-[150px]"
                 />
               </div>
 
               {/* 資格情報 */}
               <div className="flex-1">
-                <p className="font-kiwi text-3xl md:text-4xl leading-relaxed">
+                <p className="font-kiwi text-xl md:text-4xl leading-relaxed whitespace-nowrap">
                   {qualification.name} ({qualification.date})
                 </p>
               </div>

--- a/src/app/components/Works.tsx
+++ b/src/app/components/Works.tsx
@@ -44,6 +44,53 @@ const worksData: WorkItem[] = [
   },
 ];
 
+function WorkCard({ work }: { work: WorkItem }) {
+  return (
+    <div className="bg-[#374151] border-4 border-[#56FB72] rounded-lg p-8 flex flex-col items-center">
+      {/* アイコン */}
+      <div className="flex justify-center mb-6">
+        <div className="w-32 h-32 flex items-center justify-center">
+          <Image
+            src={work.icon}
+            alt={work.title}
+            width={128}
+            height={128}
+            className="rounded-lg max-w-full max-h-full object-contain"
+          />
+        </div>
+      </div>
+
+      {/* タイトル */}
+      <h3 className="font-kiwi font-medium text-2xl md:text-3xl mb-4 text-center text-white">
+        {work.title}
+      </h3>
+
+      {/* 説明文 */}
+      <div className="mb-6 space-y-2 flex-grow">
+        {work.description.map((desc, index) => (
+          <p key={index} className="font-kiwi text-lg leading-relaxed text-white text-center">
+            {desc}
+          </p>
+        ))}
+      </div>
+
+      {/* リンクボタン */}
+      <div className="flex justify-center">
+        {work.url && (
+          <a
+            href={work.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-kiwi bg-[#56FB72] hover:bg-[#4ae963] text-black px-6 py-3 rounded-lg font-medium transition-colors duration-200"
+          >
+            参考
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function Works() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const itemsPerView = 1;
@@ -69,8 +116,15 @@ export default function Works() {
           WORKS
         </h2>
 
-        {/* カルーセルコンテナ */}
-        <div className="relative">
+        {/* モバイル表示: 縦並び */}
+        <div className="flex flex-col gap-8 md:hidden">
+          {worksData.map((work) => (
+            <WorkCard key={work.id} work={work} />
+          ))}
+        </div>
+
+        {/* デスクトップ表示: カルーセル */}
+        <div className="relative hidden md:block">
           {/* 左矢印ボタン */}
           <button
             onClick={prevSlide}


### PR DESCRIPTION
## Summary
- hide interest sentences in header on mobile
- center History heading and cards, hide icons on mobile
- add mobile list layout for Works and keep carousel on desktop
- shrink Qualification icons and text for small screens

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2248e84832ca970e98cc43b99a9